### PR TITLE
Replace Plausible analytics with Umami

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -47,12 +47,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <link rel="preload" href="https://fonts.gstatic.com/s/mrssaintdelafield/v13/v6-IGZDIOVXH9xtmTZfRagunqBw5WD1MLmom3g.woff2" as="font" type="font/woff2" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet" />
 
-    <!-- Privacy-friendly analytics by Plausible -->
-    <script async src="https://plausible.io/js/pa-ZlPDFP7UruhF6-a1Pq-Ty.js"></script>
-    <script is:inline>
-      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-      plausible.init()
-    </script>
+    <!-- Privacy-friendly analytics by Umami -->
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="87cbcb59-3e3b-41db-ad60-298f5528a827"></script>
   </head>
   <body class="min-h-screen flex flex-col">
     <slot name="header">


### PR DESCRIPTION
Switch from Plausible to Umami Cloud for privacy-friendly analytics. This simplifies the tracking script to a single defer-loaded script tag.