### PR TITLE
Fix tabnabbing risk and drop inert prose classes

### DIFF
--- a/src/components/PhotoSwipeGallery.astro
+++ b/src/components/PhotoSwipeGallery.astro
@@ -20,6 +20,7 @@ const galleryId = `pswp-${id}`;
       data-pswp-width={image.width}
       data-pswp-height={image.height}
       target="_blank"
+      rel="noopener"
       class="block aspect-[3/4] overflow-hidden bg-gray-100 cursor-zoom-in"
     >
       <Image

--- a/src/pages/instruments/[slug].astro
+++ b/src/pages/instruments/[slug].astro
@@ -110,7 +110,7 @@ const productSchema = {
           </div>
 
           <!-- Description -->
-          <div class="prose prose-gray max-w-none mb-8">
+          <div class="instrument-description max-w-none mb-8">
             <Content />
           </div>
 
@@ -129,11 +129,11 @@ const productSchema = {
 <style>
   @reference "../../styles/global.css";
 
-  .prose a {
+  .instrument-description a {
     @apply text-warmgold hover:underline;
   }
 
-  .prose p {
+  .instrument-description p {
     @apply mb-4 leading-relaxed;
   }
 </style>


### PR DESCRIPTION
## Summary

- **PhotoSwipeGallery**: add `rel="noopener"` to the thumbnail links that open in a new tab. Matches the rest of the site and closes a minor tabnabbing vector.
- **instruments/[slug]**: the `prose prose-gray` classes were inert — `@tailwindcss/typography` isn't installed, so only the scoped `.prose a` / `.prose p` rules actually styled content. Renamed the hook to `.instrument-description` so the class name reflects what it does. No dependency added; all current instrument descriptions are plain paragraphs so the rendered output is unchanged.

Both are outputs from a critical review of the site.

## Test plan

- [ ] `npm run build` completes without warnings
- [ ] `/gallery` thumbnails still open PhotoSwipe lightbox; inspect element shows `rel="noopener"` on each `<a>`
- [ ] `/instruments/baroque` (and other instrument pages) render description with warmgold underlined links and paragraph spacing preserved
- [ ] No visual regression on instrument detail pages vs. main

🤖 Generated with [Claude Code](https://claude.com/claude-code)