### PR TITLE
Mark Terz Guitar as sold

### DIFF
--- a/src/content/instruments/terz.md
+++ b/src/content/instruments/terz.md
@@ -2,8 +2,7 @@
 title: Terz Guitar
 subtitle: After Stauffer 1829
 type: guitar
-status: for-sale
-price: 1250
+status: sold
 featuredImage: ../../assets/gallery/terz/hero.jpg
 images:
   - ../../assets/gallery/terz/hero.jpg


### PR DESCRIPTION
Removes for-sale status and price from the Terz Guitar listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)